### PR TITLE
Bump BlockArrays compat to 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MakieExt = "Makie"
 
 [compat]
-BlockArrays = "0.16"
+BlockArrays = "0.16,1"
 Colors = "0.12"
 GeometryBasics = "0.4.2"
 InfiniteArrays = "0.12, 0.13, 0.14"


### PR DESCRIPTION
TODO (from https://github.com/JuliaArrays/BlockArrays.jl?tab=readme-ov-file#changes-in-v10)

- [ ] BlockedArray replaces PseudoBlockArray.
- [ ] Axes are now typically BlockedOneTo instead of BlockUnitRange.
- [ ] Support for some simple block-banded matrices has been moved here from BlockBandedMatrices.jl.
- [ ] The definition of blocksizes(array::AbstractArray) is changed from blocklengths.(axes(array)) to an iterator of size
- [ ] blocksize(array) over the sizes of each block of array.
- [ ] BlockedUnitRange is now parametrized by the element type instead of hardcoded to Int.